### PR TITLE
Created custom yml loader to load player tickets, and cleanup main class

### DIFF
--- a/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
+++ b/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
@@ -1,6 +1,8 @@
 package net.runebrire.lottoplugin;
 
 import net.runebrire.lottoplugin.commands.Lottery;
+import net.runebrire.lottoplugin.util.LotteryDataLoader;
+import net.runebrire.lottoplugin.util.TicketHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -12,8 +14,8 @@ import java.io.IOException;
 
 public final class LottoPlugin extends JavaPlugin {
 
-    private File lotteryPlayerFile;
-    private FileConfiguration lotteryPlayer;
+    public static File lotteryPlayerFile;
+    public static FileConfiguration lotteryPlayer;
 
     @Override
     public void onEnable() {
@@ -22,12 +24,15 @@ public final class LottoPlugin extends JavaPlugin {
         getServer().getConsoleSender().sendMessage("LotteryPlugin Enabled");
         saveDefaultConfig();
         createLotteryPlayerConfig();
+        new TicketHandler(this);
+        LotteryDataLoader.loadTickets();
 
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+        LotteryDataLoader.saveTickets();
         getServer().getConsoleSender().sendMessage("LotteryPlugin Disabled.");
     }
 

--- a/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
+++ b/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
@@ -18,10 +18,10 @@ public final class LottoPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
-        System.out.println("Plugin is now Loading");
         this.getCommand("lottery").setExecutor(new Lottery());
         getServer().getConsoleSender().sendMessage("LotteryPlugin Enabled");
         saveDefaultConfig();
+        createLotteryPlayerConfig();
 
     }
 
@@ -33,6 +33,7 @@ public final class LottoPlugin extends JavaPlugin {
 
     public FileConfiguration getLotteryPlayerConfig() {
         return this.lotteryPlayer;
+
     }
 
     private void createLotteryPlayerConfig() {

--- a/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
+++ b/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
@@ -2,22 +2,26 @@ package net.runebrire.lottoplugin;
 
 import net.runebrire.lottoplugin.commands.Lottery;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class LottoPlugin extends JavaPlugin {
+
+    private File lotteryPlayerFile;
+    private FileConfiguration lotteryPlayer;
 
     @Override
     public void onEnable() {
         // Plugin startup logic
         System.out.println("Plugin is now Loading");
-        if(!loadConfig()){
-            getLogger().severe("Unable to load config files. Disabling plugin.");
-            Bukkit.getPluginManager().disablePlugin(this);
-        }
         this.getCommand("lottery").setExecutor(new Lottery());
         getServer().getConsoleSender().sendMessage("LotteryPlugin Enabled");
+        saveDefaultConfig();
 
     }
 
@@ -27,21 +31,23 @@ public final class LottoPlugin extends JavaPlugin {
         getServer().getConsoleSender().sendMessage("LotteryPlugin Disabled.");
     }
 
-    private boolean loadConfig() {
+    public FileConfiguration getLotteryPlayerConfig() {
+        return this.lotteryPlayer;
+    }
+
+    private void createLotteryPlayerConfig() {
+        lotteryPlayerFile = new File(getDataFolder(), "lottery-players.yml");
+        if (!lotteryPlayerFile.exists()) {
+            lotteryPlayerFile.getParentFile().mkdirs();
+            saveResource("lottery-players.yml", false);
+        }
+
+        lotteryPlayer = new YamlConfiguration();
         try {
-            if (!getDataFolder().exists()) {
-                getDataFolder().mkdirs();
-            }
-            File file = new File(getDataFolder(), "config.yml");
-            if (!file.exists()) {
-                getLogger().info("Created config.yml");
-                saveDefaultConfig();
-            }
-            return true;
-        } catch (Exception unknownError) {
-            getLogger().info("Unable to load config.yml");
-            unknownError.printStackTrace();
-            return false;
+            lotteryPlayer.load(lotteryPlayerFile);
+        } catch (IOException | InvalidConfigurationException x) {
+            x.printStackTrace();
         }
     }
+
 }

--- a/src/main/java/net/runebrire/lottoplugin/util/LotteryDataLoader.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/LotteryDataLoader.java
@@ -1,0 +1,30 @@
+package net.runebrire.lottoplugin.util;
+
+import net.runebrire.lottoplugin.LottoPlugin;
+
+import java.io.IOException;
+
+public class LotteryDataLoader {
+
+    private static LottoPlugin plugin = TicketHandler.getPlugin();
+
+    public static void saveTickets() {
+        for (String uuid : TicketHandler.getTicketMap().keySet()) {
+            plugin.getLotteryPlayerConfig().set("tickets." + uuid, TicketHandler.getTicketMap().get(uuid));
+
+        }
+        try {
+            plugin.lotteryPlayer.save(plugin.lotteryPlayerFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void loadTickets() {
+        if (!plugin.getLotteryPlayerConfig().contains("tickets")) return;
+        for (String uuid : plugin.getLotteryPlayerConfig().getConfigurationSection("tickets").getKeys(false)) {
+            TicketHandler.setTicket(uuid, plugin.getLotteryPlayerConfig().getString("tickets." + uuid));
+        }
+    }
+
+}

--- a/src/main/java/net/runebrire/lottoplugin/util/TicketHandler.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/TicketHandler.java
@@ -1,0 +1,46 @@
+package net.runebrire.lottoplugin.util;
+
+import net.runebrire.lottoplugin.LottoPlugin;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class TicketHandler {
+    public static HashMap<String, String> tickets = new HashMap<>(); //PlayerUUID, The string containing their ticket stub
+    private static LottoPlugin plugin;
+
+    public TicketHandler(LottoPlugin instance) {
+        plugin = instance;
+    }
+
+    public static void setTicket(String uuid, String generatedTicket) {
+        tickets.put(uuid, generatedTicket);
+    }
+
+    public static String getTicket(String uuid) {
+        return tickets.get(uuid);
+    }
+
+    public static boolean hasTicket(String uuid) {
+        return tickets.containsKey(uuid);
+    }
+
+    public static HashMap<String, String> getTicketMap() {
+        return tickets;
+    }
+
+    public static LottoPlugin getPlugin() {
+        return plugin;
+    }
+
+    public static boolean ticketExists(String ticket) {
+        for (String savedTicket : getTicketMap().values()) {
+            if (savedTicket.equalsIgnoreCase(ticket)) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+}

--- a/src/main/java/net/runebrire/lottoplugin/util/Util.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/Util.java
@@ -2,9 +2,15 @@ package net.runebrire.lottoplugin.util;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class Util {
     public static void sendMessage(CommandSender commandSender, String message) {
         commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
     }
+
+    public static String getUniqueId(Player player) {
+        return player.getUniqueId().toString();
+    }
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,5 @@
 #default config options, the version of the file in the jar never changes, so that if server
 #owners delete the file from the /plugins/LotteryPlugin folder it can be recreated from default settings
+# You can set the time interval by using these patterns; d for days, mo for months, hr for hours, m for minutes
+# Example; interval: 3mo, this would mean the lottery lasts three months
+interval: 7d


### PR DESCRIPTION
This PR removes some unnecessary code, and creates a custom yml loader system that manages the saving and retrieving of player's tickets on startup/shutdown. Likewise, I created a manager that makes interacting with the whole system much more convenient for when the commands are to be made, we have a custom api already to base the commands on. 
Lastly, I added a little Utilities method that converts player's UUID into a simple string, as to not have to call the same methods over and over.   