### PR TITLE
Create lottery runnable to handle lottery count down and parse config.yml interval value

### DIFF
--- a/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
+++ b/src/main/java/net/runebrire/lottoplugin/LottoPlugin.java
@@ -2,7 +2,9 @@ package net.runebrire.lottoplugin;
 
 import net.runebrire.lottoplugin.commands.Lottery;
 import net.runebrire.lottoplugin.util.LotteryDataLoader;
+import net.runebrire.lottoplugin.util.LotteryRunnable;
 import net.runebrire.lottoplugin.util.TicketHandler;
+import net.runebrire.lottoplugin.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -11,6 +13,10 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 public final class LottoPlugin extends JavaPlugin {
 
@@ -26,6 +32,25 @@ public final class LottoPlugin extends JavaPlugin {
         createLotteryPlayerConfig();
         new TicketHandler(this);
         LotteryDataLoader.loadTickets();
+        int interval = Util.parseInterval(getConfig().getString("interval"));
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm");
+        if (getLotteryPlayerConfig().getString("date").equalsIgnoreCase("0")) {
+            Calendar calendar = Calendar.getInstance();
+            Date now = new Date();
+            calendar.setTime(now);
+            calendar.add(Calendar.SECOND, interval);
+            String date = simpleDateFormat.format(calendar.getTime());
+            getLotteryPlayerConfig().set("date", date);
+            try {
+                this.lotteryPlayer.save(this.lotteryPlayerFile);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            getServer().broadcastMessage("A new lottery has begun! Get your tickets now with /lottery buy. The lottery will end at " + date);
+
+        }
+        Date lotteryEnding = Util.parseDate(getLotteryPlayerConfig().getString("date"));
+        new LotteryRunnable(this, interval, lotteryEnding).runTaskTimerAsynchronously(this, 20, 20 * 60);
 
     }
 

--- a/src/main/java/net/runebrire/lottoplugin/util/LotteryRunnable.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/LotteryRunnable.java
@@ -25,7 +25,6 @@ public class LotteryRunnable extends BukkitRunnable {
         Date todaysDate = new Date();
         long difference = lotteryEnding.getTime() - todaysDate.getTime();
         long seconds = TimeUnit.MILLISECONDS.toSeconds(difference);
-        System.out.println("Ran through here @ " + todaysDate);
         if (seconds == interval || seconds > interval) {
             plugin.getServer().broadcastMessage("The lottery has come to an end!");
             this.cancel();

--- a/src/main/java/net/runebrire/lottoplugin/util/LotteryRunnable.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/LotteryRunnable.java
@@ -1,0 +1,35 @@
+package net.runebrire.lottoplugin.util;
+
+import net.runebrire.lottoplugin.LottoPlugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class LotteryRunnable extends BukkitRunnable {
+
+    private final LottoPlugin plugin;
+    private int interval;
+    private Date lotteryEnding;
+
+    public LotteryRunnable(LottoPlugin plugin, int interval, Date lotteryEnding) {
+        this.plugin = plugin;
+        this.interval = interval;
+        this.lotteryEnding = lotteryEnding;
+    }
+
+    @Override
+    public void run() {
+        //TODO Add admin shutdown to stop lottery on the run
+        Date todaysDate = new Date();
+        long difference = lotteryEnding.getTime() - todaysDate.getTime();
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(difference);
+        System.out.println("Ran through here @ " + todaysDate);
+        if (seconds == interval || seconds > interval) {
+            plugin.getServer().broadcastMessage("The lottery has come to an end!");
+            this.cancel();
+        }
+
+    }
+}

--- a/src/main/java/net/runebrire/lottoplugin/util/Util.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/Util.java
@@ -4,6 +4,12 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
 public class Util {
     public static boolean hasPermission(Player player, String permission){
         if(player.hasPermission(permission)){
@@ -32,6 +38,18 @@ public class Util {
             return Integer.valueOf(s.replaceFirst("m", "")) * 60;
         }
         return null;
+    }
+
+
+    public static Date parseDate(String s)  {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm");
+        Date date = null;
+        try {
+            date = simpleDateFormat.parse(s);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return date;
     }
 
 

--- a/src/main/java/net/runebrire/lottoplugin/util/Util.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/Util.java
@@ -21,4 +21,18 @@ public class Util {
         return player.getUniqueId().toString();
     }
 
+    public static Integer parseInterval(String s) {
+        if (s.endsWith("d")) {
+            return Integer.valueOf(s.replaceFirst("d", "")) * 86400;
+        } else if (s.endsWith("mo")) {
+            return Integer.valueOf(s.replaceFirst("mo", "")) * 2678400;
+        } else if (s.endsWith("hr")) {
+            return Integer.valueOf(s.replaceFirst("hr", "")) * 3600;
+        } else if (s.endsWith("m")) {
+            return Integer.valueOf(s.replaceFirst("m", "")) * 60;
+        }
+        return null;
+    }
+
+
 }

--- a/src/main/java/net/runebrire/lottoplugin/util/Util.java
+++ b/src/main/java/net/runebrire/lottoplugin/util/Util.java
@@ -6,13 +6,11 @@ import org.bukkit.entity.Player;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 public class Util {
-    public static boolean hasPermission(Player player, String permission){
-        if(player.hasPermission(permission)){
+    public static boolean hasPermission(Player player, String permission) {
+        if (player.hasPermission(permission)) {
             return true;
         }
         sendMessage(player, "You must have the " + permission + " permission in order to run this command!");
@@ -41,7 +39,7 @@ public class Util {
     }
 
 
-    public static Date parseDate(String s)  {
+    public static Date parseDate(String s) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm");
         Date date = null;
         try {

--- a/src/main/resources/lottery-players.yml
+++ b/src/main/resources/lottery-players.yml
@@ -1,0 +1,5 @@
+# This file is only to store player tickets and serialize the start date for the current lottery
+# Please do not modify anything in this file unless you know what you are doing
+# The time is based on a 24hr clock
+# The date is 0 if a lottery was stopped or hasn't reset yet.
+date: 0


### PR DESCRIPTION
This creates the system for handling the countdown and recreation of the lottery. 
This also parses the config.yml `interval` value by the format laid out at the top of the config.yml. Which is converted into seconds and thus used to make sure the lottery ends on time. When a lottery is active, it's date is stored in the lottery-players.yml file seeing as that file is already meant to store data and is not meant to be modified. This could be changed to use the config.yml to allow for date changing cross restarts in the future if we would want that. 